### PR TITLE
[WIP] convert to es modules

### DIFF
--- a/dist/rollup.config.js
+++ b/dist/rollup.config.js
@@ -8,7 +8,9 @@ export default {
   format: 'cjs',
   plugins: [
     json(),
-    commonjs(),
+    commonjs({
+      include: 'node_modules/**'
+    }),
     resolve(),
   ],
   useStrict: false,

--- a/index.js
+++ b/index.js
@@ -1,13 +1,13 @@
 "use strict";
 
-const codeFrame = require("babel-code-frame");
-const comments = require("./src/comments");
-const version = require("./package.json").version;
-const printAstToDoc = require("./src/printer").printAstToDoc;
-const printDocToString = require("./src/doc-printer").printDocToString;
-const normalizeOptions = require("./src/options").normalize;
-const parser = require("./src/parser");
-const printDocToDebug = require("./src/doc-debug").printDocToDebug;
+import codeFrame from "babel-code-frame";
+import * as comments from "./src/comments";
+import { version } from "./package.json";
+import { printAstToDoc } from "./src/printer";
+import { printDocToString } from "./src/doc-printer";
+import { normalize as normalizeOptions } from "./src/options";
+import * as parser from "./src/parser";
+import { printDocToDebug } from "./src/doc-debug";
 
 function guessLineEnding(text) {
   const index = text.indexOf("\n");
@@ -85,7 +85,7 @@ function formatWithShebang(text, opts) {
   return shebang + newLine + format(programText, opts);
 }
 
-module.exports = {
+export default {
   format: function(text, opts) {
     return formatWithShebang(text, normalizeOptions(opts));
   },

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,12 +1,12 @@
 "use strict";
 
-const fs = require("fs");
-const getStdin = require("get-stdin");
-const glob = require("glob");
-const chalk = require("chalk");
-const minimist = require("minimist");
-const readline = require("readline");
-const prettier = require("../index");
+import fs from "fs";
+import getStdin from "get-stdin";
+import glob from "glob";
+import chalk from "chalk";
+import minimist from "minimist";
+import readline from "readline";
+import prettier from "../index";
 
 const argv = minimist(process.argv.slice(2), {
   boolean: [

--- a/src/comments.js
+++ b/src/comments.js
@@ -1,17 +1,16 @@
-var assert = require("assert");
-var types = require("ast-types");
+import assert from "assert";
+import types from "ast-types";
 var n = types.namedTypes;
 var isArray = types.builtInTypes.array;
 var isObject = types.builtInTypes.object;
-var docBuilders = require("./doc-builders");
-var fromString = docBuilders.fromString;
+import * as docBuilders from "./doc-builders";
 var concat = docBuilders.concat;
 var hardline = docBuilders.hardline;
 var breakParent = docBuilders.breakParent;
 var indent = docBuilders.indent;
 var lineSuffix = docBuilders.lineSuffix;
 var join = docBuilders.join;
-var util = require("./util");
+import * as util from "./util";
 var comparePos = util.comparePos;
 var childNodesCacheKey = Symbol("child-nodes");
 var locStart = util.locStart;
@@ -536,4 +535,4 @@ function printComments(path, print, options) {
   return concat(leadingParts.concat(trailingParts));
 }
 
-module.exports = { attach, printComments, printDanglingComments };
+export { attach, printComments, printDanglingComments };

--- a/src/deprecated.js
+++ b/src/deprecated.js
@@ -10,4 +10,4 @@ const deprecated = {
   }`
 };
 
-module.exports = deprecated;
+export default deprecated;

--- a/src/doc-builders.js
+++ b/src/doc-builders.js
@@ -1,7 +1,6 @@
 "use strict";
 
-import * as utils from "./doc-utils";
-const willBreak = utils.willBreak;
+import { willBreak } from "./doc-utils";
 
 function assertDoc(val) {
   if (

--- a/src/doc-builders.js
+++ b/src/doc-builders.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const utils = require("./doc-utils");
+import * as utils from "./doc-utils";
 const willBreak = utils.willBreak;
 
 function assertDoc(val) {
@@ -90,7 +90,7 @@ function join(sep, arr) {
   return concat(res);
 }
 
-module.exports = {
+export {
   concat,
   join,
   line,

--- a/src/doc-debug.js
+++ b/src/doc-debug.js
@@ -98,8 +98,8 @@ function printDoc(doc) {
   throw new Error("Unknown doc type " + doc.type);
 }
 
-module.exports = {
-  printDocToDebug: function(doc) {
-    return printDoc(flattenDoc(doc));
-  }
+const printDocToDebug = function(doc) {
+  return printDoc(flattenDoc(doc));
 };
+
+export { printDocToDebug };

--- a/src/doc-printer.js
+++ b/src/doc-printer.js
@@ -247,4 +247,4 @@ function printDocToString(doc, width, newLine) {
   return out.join("");
 }
 
-module.exports = { printDocToString };
+export { printDocToString };

--- a/src/doc-utils.js
+++ b/src/doc-utils.js
@@ -126,7 +126,7 @@ function propagateBreaks(doc) {
   );
 }
 
-module.exports = {
+export {
   isEmpty,
   getFirstString,
   willBreak,

--- a/src/fast-path.js
+++ b/src/fast-path.js
@@ -1,6 +1,6 @@
-var assert = require("assert");
-var types = require("ast-types");
-var util = require("./util");
+import assert from "assert";
+import types from "ast-types";
+import * as util from "./util";
 var n = types.namedTypes;
 var Node = n.Node;
 var isArray = types.builtInTypes.array;
@@ -625,4 +625,4 @@ FPp.firstInStatement = function() {
   return true;
 };
 
-module.exports = FastPath;
+export default FastPath;

--- a/src/fast-path.js
+++ b/src/fast-path.js
@@ -1,6 +1,6 @@
 import assert from "assert";
 import types from "ast-types";
-import * as util from "./util";
+import { getPrecedence } from "./util";
 var n = types.namedTypes;
 var Node = n.Node;
 var isArray = types.builtInTypes.array;
@@ -315,9 +315,9 @@ FPp.needsParens = function(assumeExpressionContext) {
         case "BinaryExpression":
         case "LogicalExpression":
           var po = parent.operator;
-          var pp = util.getPrecedence(po);
+          var pp = getPrecedence(po);
           var no = node.operator;
-          var np = util.getPrecedence(no);
+          var np = getPrecedence(no);
 
           if (pp > np) {
             return true;

--- a/src/options.js
+++ b/src/options.js
@@ -1,7 +1,8 @@
 "use strict";
 
-var validate = require("jest-validate").validate;
-var deprecatedConfig = require("./deprecated");
+import jest from "jest-validate";
+const { validate } = jest;
+import deprecatedConfig from "./deprecated";
 
 var defaults = {
   tabWidth: 2,
@@ -39,4 +40,4 @@ function normalize(options) {
   return normalized;
 }
 
-module.exports = { normalize };
+export { normalize };

--- a/src/parser.js
+++ b/src/parser.js
@@ -54,4 +54,4 @@ function parseWithBabylon(text) {
   });
 }
 
-module.exports = { parseWithFlow, parseWithBabylon };
+export { parseWithFlow, parseWithBabylon };

--- a/src/printer.js
+++ b/src/printer.js
@@ -7,24 +7,8 @@ import * as util from "./util";
 import esutils from 'esutils';
 var isIdentifierName = esutils.keyword.isIdentifierNameES6;
 
-import * as docBuilders from "./doc-builders";
-var concat = docBuilders.concat;
-var join = docBuilders.join;
-var line = docBuilders.line;
-var hardline = docBuilders.hardline;
-var softline = docBuilders.softline;
-var literalline = docBuilders.literalline;
-var group = docBuilders.group;
-var indent = docBuilders.indent;
-var conditionalGroup = docBuilders.conditionalGroup;
-var ifBreak = docBuilders.ifBreak;
-var breakParent = docBuilders.breakParent;
-
-import * as docUtils from "./doc-utils";
-var willBreak = docUtils.willBreak;
-var isLineNext = docUtils.isLineNext;
-var getFirstString = docUtils.getFirstString;
-var isEmpty = docUtils.isEmpty;
+import { concat, join, line, hardline, softline, literalline, group, indent, conditionalGroup, ifBreak, breakParent } from "./doc-builders";
+import { willBreak, isLineNext, getFirstString, isEmpty, propagateBreaks } from "./doc-utils";
 
 import types from "ast-types";
 var namedTypes = types.namedTypes;
@@ -2832,7 +2816,7 @@ function printAstToDoc(ast, options) {
   }
 
   const doc = printGenerically(FastPath.from(ast));
-  docUtils.propagateBreaks(doc);
+  propagateBreaks(doc);
   return doc;
 }
 

--- a/src/printer.js
+++ b/src/printer.js
@@ -1,12 +1,13 @@
 "use strict";
 
-var assert = require("assert");
-var comments = require("./comments");
-var FastPath = require("./fast-path");
-var util = require("./util");
-var isIdentifierName = require("esutils").keyword.isIdentifierNameES6;
+import assert from "assert";
+import * as comments from "./comments";
+import FastPath from "./fast-path";
+import * as util from "./util";
+import esutils from 'esutils';
+var isIdentifierName = esutils.keyword.isIdentifierNameES6;
 
-var docBuilders = require("./doc-builders");
+import * as docBuilders from "./doc-builders";
 var concat = docBuilders.concat;
 var join = docBuilders.join;
 var line = docBuilders.line;
@@ -19,13 +20,13 @@ var conditionalGroup = docBuilders.conditionalGroup;
 var ifBreak = docBuilders.ifBreak;
 var breakParent = docBuilders.breakParent;
 
-var docUtils = require("./doc-utils");
+import * as docUtils from "./doc-utils";
 var willBreak = docUtils.willBreak;
 var isLineNext = docUtils.isLineNext;
 var getFirstString = docUtils.getFirstString;
 var isEmpty = docUtils.isEmpty;
 
-var types = require("ast-types");
+import types from "ast-types";
 var namedTypes = types.namedTypes;
 var isString = types.builtInTypes.string;
 var isObject = types.builtInTypes.object;
@@ -2835,4 +2836,4 @@ function printAstToDoc(ast, options) {
   return doc;
 }
 
-module.exports = { printAstToDoc };
+export { printAstToDoc };

--- a/src/util.js
+++ b/src/util.js
@@ -1,7 +1,7 @@
 "use strict";
 
-var assert = require("assert");
-var types = require("ast-types");
+import assert from "assert";
+import types from "ast-types";
 var n = types.namedTypes;
 
 function comparePos(pos1, pos2) {
@@ -298,7 +298,7 @@ function getPrecedence(op) {
   return PRECEDENCE[op];
 }
 
-module.exports = {
+export {
   comparePos,
   getPrecedence,
   fixFaultyLocations,


### PR DESCRIPTION
So, it looks like the startup time for the bundle is slowed down by the fact that both parsers are included. A good way to work around that is to leave the inline `require` statements in place, rather than converting them to `import` declarations with rollup-plugin-commonjs.

But in order to disable the conversion, the rest of the source code needs to use `import` rather than `require`. That's what this PR does.

There are various side-benefits to doing so — better static analysis (e.g. my linter immediately found [this line](https://github.com/vjeux/prettier/blob/b93a207bb24f67646244e94d989343cc506dc34a/src/comments.js#L7) which isn't doing anything, as it refers to a non-existent export), slightly leaner/more minifiable code (because `util.fixFaultyLocations` refers to the actual function, rather than a property of a `util` object), and so on. But there is a rather substantial drawback which is that the tests don't currently work... hence the WIP!

You might not want to make this change at all, which is totally cool — just wanted to play around with it a bit and see if I could understand what's causing it to slow down, and figured I may as well share the results. Startup seems to be about 10% quicker than the master branch as of this PR.